### PR TITLE
FEATURE: outer_points

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "ints",
         "pyproj"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ geotiff = GeoTiff(tiff_file)
 array = geotiff.read_box(area_box)
 ```
 
-Getting bounding box information
+#### Getting bounding box information
+
+You can either get the points/pixels that are within a given area_box:
 
 ```python
 # col and row indexes of the cut area
@@ -78,7 +80,18 @@ int_box = geoTiff.get_int_box(area_box)
 geoTiff.get_bBox_wgs_84(area_box)
 ```
 
-Get coordinates of a point/pixel
+You can also get the points/pixels that directly surround the area_box
+
+```python
+# col and row indexes of the cut area
+int_box = geoTiff.get_int_box(area_box, outer_points = True)
+# lon and lat coords of the cut points/pixels
+geoTiff.get_bBox_wgs_84(area_box, outer_points = True)
+```
+
+This may be useful of you want to interpolate to points near the area_box boundary.
+
+#### Get coordinates of a point/pixel
 
 ```python
 i=int_box[0][0] + 5

--- a/geotiff/geotiff.py
+++ b/geotiff/geotiff.py
@@ -260,7 +260,7 @@ class GeoTiff():
         return(((x_min, y_min),(x_max, y_max)))
 
 
-    def get_bBox_wgs_84(self, bBox: BBox) -> BBox:
+    def get_bBox_wgs_84(self, bBox: BBox, outer_points: bool = False) -> BBox:
         """takes a bounding area gets the coordinates of the extremities
         as if they were clipped by that bounding area
 
@@ -270,7 +270,7 @@ class GeoTiff():
         Returns: 
             BBox: in wgs_84
         """
-        b = self.get_int_box(bBox)
+        b = self.get_int_box(bBox, outer_points=outer_points)
         left_top = self.get_wgs_84_coords(b[0][0], b[0][1])
         right_bottom = self.get_wgs_84_coords(b[1][0], b[1][1])
         return((left_top, right_bottom))

--- a/geotiff/geotiff.py
+++ b/geotiff/geotiff.py
@@ -230,6 +230,7 @@ class GeoTiff():
 
         Args:
             bBox (BBox): A bounding box
+            outer_points (bool = False): When True, includes the points/pixels that directly surround the bBox
 
         Raises:
             BoundaryNotInTifError: If the boundary is not enclosed withing the 
@@ -266,6 +267,7 @@ class GeoTiff():
 
         Args:
             bBox (BBox): bounding box area to clip within (wgs_84)
+            outer_points (bool = False): When True, includes the points/pixels that directly surround the bBox
 
         Returns: 
             BBox: in wgs_84
@@ -279,11 +281,20 @@ class GeoTiff():
         """Reade the contents of the geotiff to a zarr array
 
         Returns:
-            List[List[Union[int,float]]]: zarr array of the geotiff file
+            np.ndarray: zarr array of the geotiff file
         """
         return(self.z)
 
     def read_box(self, bBox: BBox, outer_points: bool = False) -> np.ndarray:
+        """[summary]
+
+        Args:
+            bBox (BBox): A bounding box
+            outer_points (bool, optional): When True, includes the points/pixels that directly surround the bBox. Defaults to False.
+
+        Returns:
+            np.ndarray: zarr array of the geotiff file
+        """
         ((x_min,y_min),(x_max,y_max)) = self.get_int_box(bBox, outer_points=outer_points)
         tiff_array = self.read()
         cut_tif_array: np.ndarray = tiff_array[y_min:y_max, x_min:x_max]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 import sys
 from setuptools.command.install import install
 
-VERSION = "0.1.6"
+VERSION = "0.1.7"
 
 # Send to pypi
 # python3 setup.py sdist bdist_wheel

--- a/tests/test_geotiff.py
+++ b/tests/test_geotiff.py
@@ -8,17 +8,17 @@ from geotiff import GeoTiff
 def tiff_file():
     filename = "dem.tif"
     dir = dir = "./tests/inputs/"
-    return(os.path.join(dir, filename))
+    return os.path.join(dir, filename)
 
 
 @pytest.fixture
 def area_box():
-    return([(138.632071411, -32.447310785), (138.644218874, -32.456979174)])
+    return [(138.632071411, -32.447310785), (138.644218874, -32.456979174)]
 
 
 @pytest.fixture
 def geoTiff(tiff_file):
-    return(GeoTiff(tiff_file))
+    return GeoTiff(tiff_file)
 
 
 def test_read(tiff_file, area_box, geoTiff: GeoTiff):
@@ -49,13 +49,12 @@ def test_int_box_outer(area_box, geoTiff: GeoTiff):
     assert isinstance(intBox[1], tuple)
     assert ((125, 143), (170, 179)) == intBox
 
+
 def test_conversions(area_box, geoTiff: GeoTiff):
     int_box = geoTiff.get_int_box(area_box)
-    geoTiff.get_bBox_wgs_84(area_box)
-    i=int_box[0][0] + 5
-    j=int_box[0][1] + 6
+    i = int_box[0][0] + 5
+    j = int_box[0][1] + 6
     geoTiff.get_wgs_84_coords(i, j)
-    print(area_box)
     bounding_box = geoTiff.get_bBox_wgs_84(area_box)
     assert area_box[0][0] <= bounding_box[0][0]
     assert area_box[0][1] >= bounding_box[0][1]
@@ -63,7 +62,19 @@ def test_conversions(area_box, geoTiff: GeoTiff):
     assert area_box[1][1] <= bounding_box[1][1]
 
     assert geoTiff.read_box(area_box).shape == (34, 43)
-    assert geoTiff.read_box(area_box, outer_points=True).shape == (36, 45)
-    assert geoTiff.tif_bBox_wgs_84 == (
-        (138.5972222222219, -32.40749999999997), (138.69055555555522, -32.49138888888886))
+    assert geoTiff.get_bBox_wgs_84(area_box) == (
+        (138.63222222222188, -32.44749999999997),
+        (138.64416666666634, -32.45694444444442),
+    )
 
+    assert geoTiff.read_box(area_box, outer_points=True).shape == (36, 45)
+
+    assert geoTiff.get_bBox_wgs_84(area_box, outer_points=True) == (
+        (138.63194444444412, -32.447222222222194),
+        (138.6444444444441, -32.45722222222219),
+    )
+
+    assert geoTiff.tif_bBox_wgs_84 == (
+        (138.5972222222219, -32.40749999999997),
+        (138.69055555555522, -32.49138888888886),
+    )

--- a/tests/test_geotiff.py
+++ b/tests/test_geotiff.py
@@ -41,6 +41,14 @@ def test_int_box(area_box, geoTiff: GeoTiff):
     assert ((126, 144), (169, 178)) == intBox
 
 
+def test_int_box_outer(area_box, geoTiff: GeoTiff):
+    intBox = geoTiff.get_int_box(area_box, outer_points=True)
+    assert isinstance(intBox, tuple)
+    assert len(intBox) == 2
+    assert isinstance(intBox[0], tuple)
+    assert isinstance(intBox[1], tuple)
+    assert ((125, 143), (170, 179)) == intBox
+
 def test_conversions(area_box, geoTiff: GeoTiff):
     int_box = geoTiff.get_int_box(area_box)
     geoTiff.get_bBox_wgs_84(area_box)
@@ -54,6 +62,8 @@ def test_conversions(area_box, geoTiff: GeoTiff):
     assert area_box[1][0] >= bounding_box[1][0]
     assert area_box[1][1] <= bounding_box[1][1]
 
-    print(geoTiff.read_box(area_box).shape)
+    assert geoTiff.read_box(area_box).shape == (34, 43)
+    assert geoTiff.read_box(area_box, outer_points=True).shape == (36, 45)
     assert geoTiff.tif_bBox_wgs_84 == (
         (138.5972222222219, -32.40749999999997), (138.69055555555522, -32.49138888888886))
+


### PR DESCRIPTION
outer_points (bool, optional): When True, includes the points/pixels that directly surround the bBox. Defaults to False.

UI example: 

```python
# col and row indexes of the cut area
int_box = geoTiff.get_int_box(area_box, outer_points = True)
# lon and lat coords of the cut points/pixels
geoTiff.get_bBox_wgs_84(area_box, outer_points = True)
```